### PR TITLE
Add support for Windows .exe compilers

### DIFF
--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -26,8 +26,8 @@ from compiledb.compiler import get_compiler
 from compiledb.utils import run_cmd
 
 # Internal variables used to parse build log entries
-cc_compile_regex = re.compile(r"^.*-?g?cc-?[0-9.]*$|^.*-?clang-?[0-9.]*$")
-cpp_compile_regex = re.compile(r"^.*-?[gc]\+\+-?[0-9.]*$|^.*-?clang\+\+-?[0-9.]*$")
+cc_compile_regex = re.compile(r"^.*-?g?cc-?[0-9.]*(?:.exe)?$|^.*-?clang-?[0-9.]*(?:.exe)?$")
+cpp_compile_regex = re.compile(r"^.*-?[gc]\+\+-?[0-9.]*(?:.exe)?$|^.*-?clang\+\+-?[0-9.]*(?:.exe)?$")
 file_regex = re.compile(r"^.+\.c$|^.+\.cc$|^.+\.cpp$|^.+\.cxx$|^.+\.s$", re.IGNORECASE)
 compiler_wrappers = {"ccache", "icecc", "sccache"}
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -55,6 +55,24 @@ def test_trivial_build_command():
     }
 
 
+def test_trivial_build_command_windows():
+    pwd = getcwd()
+    build_log = ['gcc.exe -o hello.o -c hello.c']
+    result = parse_build_log(
+        build_log,
+        proj_dir=pwd,
+        exclude_files=[])
+
+    assert result.count == 1
+    assert result.skipped == 0
+    assert len(result.compdb) == 1
+    assert result.compdb[0] == {
+        'directory': pwd,
+        'file': 'hello.c',
+        'arguments': ['gcc.exe', '-o', 'hello.o', '-c', 'hello.c']
+    }
+
+
 def test_build_commands_with_version():
     pwd = getcwd()
     build_log = ['clang-5.0 -o hello.o -c hello.c']


### PR DESCRIPTION
I'm on Windows and there the compiler executable sometimes ends with .exe. This is a small patch to handle such case.